### PR TITLE
Fix bug of reading kubelet checkpoint file failed

### DIFF
--- a/pkg/services/allocator/nvidia/allocator.go
+++ b/pkg/services/allocator/nvidia/allocator.go
@@ -815,7 +815,7 @@ func (ta *NvidiaTopoAllocator) PreStartContainer(ctx context.Context, req *plugi
 
 	// try to get podUID, containerName, vcore and vmemory from kubelet deviceplugin checkpoint file
 	cp, err := utils.GetCheckpointData(ta.config.DevicePluginPath)
-	if err != nil {
+	if err != nil || cp == nil {
 		msg := fmt.Sprintf("%s, failed to read from checkpoint file due to %v",
 			types.PreStartContainerCheckErrMsg, err)
 		klog.Infof(msg)

--- a/pkg/services/response/manager.go
+++ b/pkg/services/response/manager.go
@@ -38,6 +38,9 @@ func (m *responseManager) LoadFromFile(path string) error {
 	if err != nil {
 		return err
 	}
+	if cp == nil {
+		return nil
+	}
 
 	for _, item := range cp.PodDeviceEntries {
 		// Only vcore resource has valid response data

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -126,6 +127,10 @@ func GetCheckpointData(devicePluginPath string) (*types.Checkpoint, error) {
 	cpFile := filepath.Join(devicePluginPath, types.CheckPointFileName)
 	data, err := ioutil.ReadFile(cpFile)
 	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(4).Infof("Failed to read data from checkpoint: No such file")
+			return nil, nil
+		}
 		return nil, err
 	}
 	klog.V(4).Infof("Try NUMA checkpoint data format")


### PR DESCRIPTION
If there is no device plugin registed, kubelet_internal_checkpoint will not be created. GPU Manager should skip reading checkpoint file at the initialization period.